### PR TITLE
Text related bugfixes

### DIFF
--- a/src/gui/cordinates.cpp
+++ b/src/gui/cordinates.cpp
@@ -24,7 +24,7 @@ Size::Size(Vector start, Vector end): width(end.x - start.x), height(end.y - sta
 
 LocalVector Size::start_to_end() const
 {
-    return LocalVector(width, height);
+    return LocalVector(width - 1, height - 1);
 }
 
 Size Size::operator+(const Vector &other) const

--- a/src/gui/engines/GxEPD_GraphicsEngine.cpp
+++ b/src/gui/engines/GxEPD_GraphicsEngine.cpp
@@ -231,7 +231,7 @@ cord_t GxEPD_GraphicsEngine::Fonts::get_char_width(font_id_t font, char c)
 bool GxEPD_GraphicsEngine::Fonts::is_legit_char(font_id_t font, char c)
 {
     const GFXfont *adafruit_font =  _fonts[font].font;
-    return c < adafruit_font->first or c > adafruit_font->last;
+    return adafruit_font->first < c and c < adafruit_font->last;
 }
 
 size_t GxEPD_GraphicsEngine::Fonts::first_non_legit_char(font_id_t font, const char* str)


### PR DESCRIPTION
Fixed:
- GxEPD_GraphicsEngine::Fonts::is_legit_char fixed (behavior was inversed)
- All derived methods also now works correctly: get_char_width, get_string_width
- Size::start_to_end now returns real start->end vector, this behavior caused 1-pixel error while text clipping